### PR TITLE
Fix support for PHP 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": "^7.1.3 | ^8.0",
+    "php": "^7.1.3 || ^8.0",
     "flagception/flagception": "^1.7",
     "doctrine/dbal":  "^2.12",
     "symfony/options-resolver": ">=2.7"

--- a/src/Activator/DatabaseActivator.php
+++ b/src/Activator/DatabaseActivator.php
@@ -94,7 +94,7 @@ class DatabaseActivator implements FeatureActivatorInterface
                 'SELECT %s FROM %s WHERE %s = :feature_name',
                 $this->options['db_column_state'],
                 $this->options['db_table'],
-                $this->options['db_column_feature'],
+                $this->options['db_column_feature']
             ),
             ['feature_name' => $name]
         )->fetchOne();


### PR DESCRIPTION
Trailing Commas are NOT allowed in calls before PHP 7.3

https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.trailing-commas

This PR should also fix tests in https://github.com/playox/flagception-bundle which run tests using PHP 7.2